### PR TITLE
CI: Consolidate workflow for local testing with act

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,11 @@ on:
         required: false
         default: false
         type: boolean
+      skip_build:
+        description: "Skip build and use local image (for local testing with act)"
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   # ============================================
@@ -121,6 +126,7 @@ jobs:
     name: Integration Tests
     runs-on: ubuntu-latest
     needs: build-test-image
+    if: ${{ !inputs.skip_build }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -146,9 +152,49 @@ jobs:
           sudo ./install.sh /usr/local
 
       - name: Run integration tests
-        env:
-          CI: true
         run: bats tests/integration/
+
+  integration-tests-local:
+    name: Integration Tests (Local Image)
+    runs-on: ubuntu-latest
+    if: ${{ inputs.skip_build }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Verify Docker image exists
+        run: |
+          echo "Checking for locally-built Docker image..."
+          if docker images | grep -q "jmcombs/powershell.*latest"; then
+            echo "✅ Found jmcombs/powershell:latest"
+            docker images | grep powershell
+          else
+            echo "❌ Error: jmcombs/powershell:latest not found"
+            echo ""
+            echo "Please build the image first:"
+            echo "  ./scripts/build-local-arm64.sh"
+            exit 1
+          fi
+
+      - name: Install bats-core
+        run: |
+          git clone https://github.com/bats-core/bats-core.git /tmp/bats-core
+          cd /tmp/bats-core
+          sudo ./install.sh /usr/local
+
+      - name: Run integration tests
+        run: bats tests/integration/
+
+      - name: Test summary
+        if: always()
+        run: |
+          echo ""
+          echo "================================================"
+          echo "Integration Tests Complete"
+          echo "================================================"
+          echo ""
+          echo "Image tested: jmcombs/powershell:latest"
+          docker images | grep powershell || true
 
   # ============================================
   # Stage 4: Publish (only on main, after tests)
@@ -157,8 +203,14 @@ jobs:
   publish:
     name: Build and Publish
     runs-on: ubuntu-latest
-    needs: integration-tests
-    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+    needs: [integration-tests, integration-tests-local]
+    if: |
+      always() &&
+      github.ref == 'refs/heads/main' &&
+      github.event_name != 'pull_request' &&
+      !inputs.skip_build &&
+      (needs.integration-tests.result == 'success' || needs.integration-tests.result == 'skipped') &&
+      (needs.integration-tests-local.result == 'success' || needs.integration-tests-local.result == 'skipped')
     permissions:
       contents: write
     steps:

--- a/scripts/build-local-arm64.sh
+++ b/scripts/build-local-arm64.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+set -e
+
+# Build Docker image locally for ARM64 (Apple Silicon)
+# This script builds the image natively without QEMU emulation issues
+
+echo "🔧 Building PowerShell Docker image for ARM64 (Apple Silicon)..."
+
+# Get version information
+echo "📋 Getting .NET and PowerShell versions..."
+chmod +x ./scripts/get-net-pwsh-versions.sh
+./scripts/get-net-pwsh-versions.sh
+
+# Source the environment variables
+if [ -f /tmp/env_vars ]; then
+    echo "✅ Loading build arguments from /tmp/env_vars"
+    export $(cat /tmp/env_vars | xargs)
+else
+    echo "❌ Error: /tmp/env_vars not found"
+    exit 1
+fi
+
+# Build the image for ARM64
+echo "🐳 Building Docker image for linux/arm64..."
+docker buildx build \
+    --platform linux/arm64 \
+    --build-arg NET_RUNTIME_LTS_VERSION="${NET_RUNTIME_LTS_VERSION}" \
+    --build-arg NET_RUNTIME_URL_arm="${NET_RUNTIME_URL_arm}" \
+    --build-arg NET_RUNTIME_PACKAGE_NAME_arm="${NET_RUNTIME_PACKAGE_NAME_arm}" \
+    --build-arg NET_RUNTIME_URL_arm64="${NET_RUNTIME_URL_arm64}" \
+    --build-arg NET_RUNTIME_PACKAGE_NAME_arm64="${NET_RUNTIME_PACKAGE_NAME_arm64}" \
+    --build-arg NET_RUNTIME_URL_x64="${NET_RUNTIME_URL_x64}" \
+    --build-arg NET_RUNTIME_PACKAGE_NAME_x64="${NET_RUNTIME_PACKAGE_NAME_x64}" \
+    --build-arg PWSH_LTS_URL_arm32="${PWSH_LTS_URL_arm32}" \
+    --build-arg PWSH_LTS_PACKAGE_NAME_arm32="${PWSH_LTS_PACKAGE_NAME_arm32}" \
+    --build-arg PWSH_LTS_URL_arm64="${PWSH_LTS_URL_arm64}" \
+    --build-arg PWSH_LTS_PACKAGE_NAME_arm64="${PWSH_LTS_PACKAGE_NAME_arm64}" \
+    --build-arg PWSH_LTS_URL_x64="${PWSH_LTS_URL_x64}" \
+    --build-arg PWSH_LTS_PACKAGE_NAME_x64="${PWSH_LTS_PACKAGE_NAME_x64}" \
+    --build-arg PWSH_LTS_VERSION="${PWSH_LTS_VERSION}" \
+    --build-arg PWSH_LTS_MAJOR_VERSION="${PWSH_LTS_MAJOR_VERSION}" \
+    --load \
+    --tag jmcombs/powershell:test \
+    --tag jmcombs/powershell:latest \
+    .
+
+echo ""
+echo "✅ Build complete!"
+echo ""
+echo "📦 Tagged images:"
+echo "   - jmcombs/powershell:test"
+echo "   - jmcombs/powershell:latest"
+echo ""
+
+# Tag the image as 'latest' for integration tests
+echo "🏷️  Tagging image as latest for integration tests..."
+docker tag jmcombs/powershell:test jmcombs/powershell:latest
+
+# Run integration tests with act using the main CI workflow with skip_build input
+echo "🧪 Running integration tests with act..."
+echo ""
+
+if command -v act &> /dev/null; then
+    # Use the main ci.yml workflow with skip_build=true to bypass the build job
+    # This runs the integration-tests-local job which assumes the image already exists
+    act workflow_dispatch --pull=false --input skip_build=true -j integration-tests-local
+    TEST_EXIT_CODE=$?
+
+    echo ""
+    if [ $TEST_EXIT_CODE -eq 0 ]; then
+        echo "✅ All integration tests passed!"
+    else
+        echo "❌ Integration tests failed with exit code: $TEST_EXIT_CODE"
+        exit $TEST_EXIT_CODE
+    fi
+else
+    echo "⚠️  Warning: 'act' is not installed. Skipping integration tests."
+    echo ""
+    echo "   Install act with:"
+    echo "   brew install act"
+    echo ""
+    echo "   To run tests manually:"
+    echo "   act workflow_dispatch --pull=false --input skip_build=true -j integration-tests-local"
+fi
+
+echo ""
+echo "🚀 To run the container:"
+echo "   docker run -it jmcombs/powershell:latest"
+


### PR DESCRIPTION
## Summary

This PR consolidates the CI workflow to support local testing on Apple Silicon using `act` with locally-built ARM64 images.

## Changes

- ✅ Add `skip_build` workflow input to support local testing scenarios
- ✅ Create dual integration test jobs:
  - `integration-tests`: Normal CI pipeline (builds and tests)
  - `integration-tests-local`: Local testing (uses pre-built image)
- ✅ Add `scripts/build-local-arm64.sh` for automated Apple Silicon builds
- ✅ Update `CONTRIBUTING.md` with local testing documentation
- ✅ Fix markdown linting issues in `CONTRIBUTING.md`
- ✅ Update test structure documentation

## Testing

- [ ] CI pipeline passes with normal workflow
- [ ] Local testing works with `./scripts/build-local-arm64.sh`
- [ ] Integration tests run successfully in both modes

## Related Issues

Addresses the need for native ARM64 testing on Apple Silicon without QEMU emulation issues.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author