### PR TITLE
fix: use locale-gen for en_US.UTF-8 on Ubuntu 26.04+

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,9 +47,13 @@ RUN apt-get update \
     unzip \
     wget
 
-# Set US English and UTF-8 Locale
-RUN localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
-ENV LANG=en_US.utf8
+# Set US English and UTF-8 Locale (Ubuntu 24.04+/26.04 compatible)
+RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen \
+    && locale-gen en_US.UTF-8 \
+    && update-locale LANG=en_US.UTF-8
+ENV LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \
+    LC_ALL=en_US.UTF-8
 
 # Defining non-root User
 ARG USERNAME=coder

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,7 @@ RUN apt-get update \
     wget
 
 # Set US English and UTF-8 Locale (Ubuntu 24.04+/26.04 compatible)
+# Uses the recommended modern Ubuntu pattern (locale-gen + update-locale)
 RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen \
     && locale-gen en_US.UTF-8 \
     && update-locale LANG=en_US.UTF-8


### PR DESCRIPTION
## Summary

The CI/CD pipeline has been failing for several weeks on the locale generation step because Ubuntu 26.04 (resolute) no longer ships `/usr/share/locale/locale.alias` after a minimal `locales` install.

**Error:**
```
locale alias file `/usr/share/locale/locale.alias' not found: No such file or directory
```

## Changes

Replaced the legacy `localedef` command that depended on the missing alias file with the recommended Ubuntu approach:

```dockerfile
RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen \
    && locale-gen en_US.UTF-8 \
    && update-locale LANG=en_US.UTF-8
ENV LANG=en_US.UTF-8 \
    LANGUAGE=en_US:en \
    LC_ALL=en_US.UTF-8
```

This is the official/preferred way on modern Ubuntu and works across 22.04 → 24.04 → 26.04.

## Validation

- Fixes the exact failure seen in recent scheduled runs (e.g. run 30725451495)
- Uses Ubuntu’s intended tools (`locale-gen` / `update-locale`)
- Maintains the original intent of providing `en_US.UTF-8` as the default locale