### PR TITLE
fix(docker): add libicu* for .NET/PowerShell globalization on Ubuntu 26.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN	if id "ubuntu" &>/dev/null; then \
     fi;
 
 # Install sudo and other necessary packages
+# libicu* is required by .NET/PowerShell for globalization (FailFast without it)
 RUN apt-get update \
     && apt-get -y install --no-install-recommends \
     apt-transport-https \
@@ -41,6 +42,7 @@ RUN apt-get update \
     fontconfig \
     git \
     jq \
+    libicu* \
     locales \
     software-properties-common \
     sudo \


### PR DESCRIPTION
## Summary

Fixes the Docker build failure introduced after the locale fix.

**Error:**
```
Process terminated. Couldn't find a valid ICU package installed on the system.
Please install libicu (or icu-libs) using your package manager and try again.
...
Aborted (core dumped)
```

## Root cause
.NET / PowerShell requires the ICU libraries for globalization. The previous package list installed `locales` but not the ICU runtime. On `ubuntu:latest` (currently 26.04) this causes `pwsh` to FailFast when the module-install step runs.

## Change
Add `libicu*` to the `apt-get install` list in the base stage. On current Ubuntu this resolves to `libicu78`. The wildcard keeps the Dockerfile forward-compatible as Ubuntu advances ICU versions.

No base-image pin (stays on `ubuntu:latest` per preference).

## Test plan
- [x] Confirmed `libicu78` is the runtime package on Ubuntu 26.04 / `ubuntu:latest`
- [x] Matches Microsoft’s own PowerShell Dockerfiles (they install the versioned `libicuNN` package)
- [ ] CI build succeeds after merge